### PR TITLE
Add test for diddlesnaps/snapcraft-multiarch-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - run: |
         npm install
         npm run all
-  integration: # make sure the action works on a clean machine without building
+  integration-snapcore: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -25,3 +25,15 @@ jobs:
     - uses: ./
       with:
         snap: ${{ steps.build.outputs.snap }}
+  integration-multiarch: # make sure the action works on a clean machine without building
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: diddlesnaps/snapcraft-multiarch-action@v1
+      id: build
+      with:
+        path: './sample-project'
+    - uses: ./
+      with:
+        snap: ${{ steps.build.outputs.snap }}
+    


### PR DESCRIPTION
While working on ODM I found that the review-tools refuse to run when
using `diddlesnaps/snapcraft-multiarch-action`, so this adds a test to
try to catch the error.

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>