### PR TITLE
build: run on node20 rather than deprecated node12

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,5 +12,5 @@ inputs:
   isClassic:
     description: 'Set this to true if you are reviewing a classic snap'
 runs:
-  using: 'node12'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Presently, use of this action triggers a deprecation warning due to the use of an older version of NodeJS

https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/